### PR TITLE
teaching-friendly diologue interface test

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,91 +1,83 @@
+var dialogue = require('./dialogue');
 var restify = require('restify');
 var builder = require('botbuilder');
 
 // Setup Restify Server
 var server = restify.createServer();
-server.listen(process.env.port || process.env.PORT || 3978, function () {
-   console.log('%s listening to %s', server.name, server.url); 
+server.listen(process.env.port || process.env.PORT || 3978, function() {
+  console.log('%s listening to %s', server.name, server.url);
 });
 
 // Create chat connector for communicating with the Bot Framework Service
 var connector = new builder.ChatConnector({
-    appId: null,
-    appPassword: null
+  appId: null,
+  appPassword: null
 });
 
-// Listen for messages from users 
+// Listen for messages from users
 server.post('/api/messages', connector.listen());
 
 // Receive messages from the user and respond by echoing each message back (prefixed with 'You said:')
-var bot = new builder.UniversalBot(connector, function (session) {
-    session.send("Jag förstår inte vad du menar med: %s", session.message.text);
+var bot = new builder.UniversalBot(connector, function(session) {
+  session.send(dialogue.otydligText, session.message.text);
 });
 
 
-bot.on('conversationUpdate', function (message) {
-    if (message.membersAdded) {
-        const hello = new builder.Message()
-            .address(message.address)
-            .text("Hej! Jag är PartyBoten, sugen på fest? Fråga då efter min Hjälp.");
-        bot.send(hello);
+bot.on('conversationUpdate', function(message) {
+  if (message.membersAdded) {
+    const hello = new builder.Message()
+      .address(message.address)
+      .text(dialogue.introText);
+    bot.send(hello);
+  }
+});
+
+
+// Simple dialogues
+dialogue.intents.forEach(function(intentItem) {
+  bot.dialog(intentItem.intent + 'Dialog', function(session) {
+    if (intentItem.action) {
+      // Dialogue with waterfall
+      session.beginDialog(intentItem.action);
+    } else {
+      // Simple response dialogue
+      session.endDialog(intentItem.response);
     }
+  }).triggerAction({ matches: intentItem.intent });
 });
 
-// Text messages
-bot.dialog('helpDialog', function (session) {
-    session.endDialog("Okej... du vill ha min hjälp. Hur många vill du bjuda till festen? Skriv: 'Boka'... eller 'Hejdå' för att lämna mig :(");
-}).triggerAction({ matches: 'Hjälp' });
-
-bot.dialog('bokaDialog', function (session) {
-    session.beginDialog('ticketsDialog');
-}).triggerAction({ matches: 'Boka' });
-
-bot.dialog('okDialog', function (session) {
-    session.endDialog("Du kan vara... ok!");
-}).triggerAction({ matches: 'Ok' });
 
 // Prompts
 bot.dialog('ticketsDialog', [
-    function (session) {
-        builder.Prompts.text(session, 'Hur många biljetter vill du reservera?');
-    },
-    function (session, results) {
-        var amount = results.response;
-        var isNum = /^\d+$/.test(amount);
-        
-        if (isNum) {
-            session.endDialog(`Perfekt! Nu har jag reserverat: ${amount} biljetter`);
-        } else {
-            session.endDialog(`Mäh! ${amount} är ingen siffra... Inga problem, vi försöker igen!`);
-            session.beginDialog('ticketsDialog');
-        }
+  function(session) {
+    builder.Prompts.text(session, 'Hur många biljetter vill du reservera?');
+  },
+  function(session, results) {
+    var amount = results.response;
+    var isNum = /^\d+$/.test(amount);
+
+    if (isNum) {
+      session.endDialog(`Perfekt! Nu har jag reserverat: ${amount} biljetter`);
+    } else {
+      session.endDialog(`Mäh! ${amount} är ingen siffra... Inga problem, vi försöker igen!`);
+      session.beginDialog('ticketsDialog');
     }
+  }
 ]);
 
 
-
-bot.endConversationAction('goodbyeAction', "Okej... See you later aligator.", { matches: 'Hejdå' });
-
 bot.recognizer({
-    recognize: function (context, done) {
-        var intent = { score: 0.0 };
+  recognize: function(context, done) {
+    var intent = { score: 0.0 };
 
-        if (context.message.text) {
-            switch (context.message.text.toLowerCase()) {
-                case 'hjälp' :
-                    intent = { score: 1.0, intent: 'Hjälp' };
-                    break;
-                case 'boka' :
-                    intent = { score: 1.0, intent: 'Boka' };
-                    break;
-                case 'ok' :
-                    intent = { score: 1.0, intent: 'Ok' };
-                    break;
-                case 'hejdå' :
-                    intent = { score: 1.0, intent: 'Hejdå' };
-                    break;
-            }
+    if (context.message.text) {
+      dialogue.intents.forEach(function(intentItem) {
+        if (context.message.text.toLowerCase() === intentItem.intent) {
+          intent = { score: 1.0, intent: intentItem.intent };
         }
-        done(null, intent);
+      });
+
     }
+    done(null, intent);
+  }
 });

--- a/dialogue.js
+++ b/dialogue.js
@@ -1,0 +1,16 @@
+var introText = "Hej! Jag är PartyBoten, sugen på fest? Fråga då efter min Hjälp.";
+
+var otydligText = "Jag förstår inte vad du menar med: %s";
+
+var intents = [
+  {intent: 'hjälp', response: "Okej... du vill ha min hjälp. Hur många vill du bjuda till festen? Skriv: 'Boka'... eller 'Hejdå'"},
+  {intent: 'boka', response: "", action: "ticketsDialog"},
+  {intent: 'ok', response: "Du kan vara... ok!"},
+  {intent: 'hejdå', response: "Okej... See you later aligator."}
+]
+
+module.exports = {
+  introText,
+  otydligText,
+  intents
+};

--- a/dialogue.js
+++ b/dialogue.js
@@ -1,12 +1,21 @@
-var introText = "Hej! Jag är PartyBoten, sugen på fest? Fråga då efter min Hjälp.";
 
-var otydligText = "Jag förstår inte vad du menar med: %s";
+// gränsnittet för kod under stationen
+// Frågorna fylls i under stationsaktivitet
+// TODO: bestäm startmallformat för stationen + konsekens och samma språk igenom denna sida + övriga förbättringar vi hinner med.
+//
+var introText = "Här skrivs en hälsning";
 
-var intents = [
-  {intent: 'hjälp', response: "Okej... du vill ha min hjälp. Hur många vill du bjuda till festen? Skriv: 'Boka'... eller 'Hejdå'"},
-  {intent: 'boka', response: "", action: "ticketsDialog"},
-  {intent: 'ok', response: "Du kan vara... ok!"},
-  {intent: 'hejdå', response: "Okej... See you later aligator."}
+var otydligText = "Här skrivs svar på okänd fråga %s";
+
+var intents = [{
+    intent: "enkel fråga",
+    response: "Direkt svar"
+  },
+  {
+    intent: "fråga med svar",
+    response: "Prompt för input",
+    action: (results) => `Svar med input: ${results.response}`
+  }
 ]
 
 module.exports = {


### PR DESCRIPTION
Seperated dialogue options from app.js to dialogue js to try to create a simple code interface for teaching. Restricted dialogue options to 2 types of questions. 

- **Question > Response**: Recognises intent key phrase and responds with text string answer.
- **Question > Prompt for Input > Response with Input**:  Recognises intent key phrase, prompts for further input and responds with text string included user input value.

Both types of questions accessible through dialogue.js.